### PR TITLE
remove get_pm_compilers()

### DIFF
--- a/compiler-shadow.eselect
+++ b/compiler-shadow.eselect
@@ -68,13 +68,6 @@ get_installed_tools() {
 			echo "${t}"
 	done
 }
-
-# print list of compilers used by the package manager
-get_pm_compilers() {
-	# TODO: can we get some valid package name out of it?
-	envvar sys-apps/baselayout CC
-	envvar sys-apps/baselayout CXX
-}
 # }}}
 
 ## {{{ update masquerade
@@ -100,7 +93,6 @@ do_update() {
 	[[ ${tools} == all ]] && tools=( $(get_installed_tools) )
 	[[ ${wildcards} ]] || wildcards=(
 		"${MASQ_COMPILER_WILDCARDS[@]}"
-		$(get_pm_compilers)
 	)
 	local t
 	for t in "${tools[@]}"; do


### PR DESCRIPTION
there's no real need for this function as compilers are already covered by
modules/compilers patterns. Additionally, if the user set CC to a full
path, then this would lead to the path being removed! The behaviour could
also get unpredictable when CC is set to multiple executables
(i.e. CC=/usr/bin/ccache /usr/bin/gcc)