### PR TITLE
clean: skip symlinks to directories

### DIFF
--- a/compiler-shadow.eselect
+++ b/compiler-shadow.eselect
@@ -154,6 +154,11 @@ do_clean() {
 		cd "${out_dir}" || die
 		local p
 		for p in *; do
+			if [[ -d ${p} ]]; then
+				# Avoid removing distcc compat symlink
+				# https://bugs.gentoo.org/942759
+				continue
+			fi
 			if ! type -P "${p}" &>/dev/null; then
 				rm -v "${p}"
 			fi

--- a/compiler-shadow.eselect
+++ b/compiler-shadow.eselect
@@ -5,7 +5,7 @@ inherit package-manager
 
 DESCRIPTION="Manage compiler shadow link directories (distcc, ccache)"
 MAINTAINER="mgorny@gentoo.org"
-VERSION=3
+VERSION=4
 
 # {{{ substitution variables
 MASQ_MODULEDIR=$(dirname $(realpath "${BASH_SOURCE}"))/modules


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/942759